### PR TITLE
remove dot in opam synopsis field

### DIFF
--- a/slack.opam
+++ b/slack.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ahrefs/slack"
 bug-reports: "https://github.com/ahrefs/slack/issues"
 dev-repo: "git+https://github.com/ahrefs/slack.git"
 
-synopsis: "Slack API implementation."
+synopsis: "Slack API implementation"
 description: "OCaml interface for accessing Slack APIs and receiving events."
 
 depends: [


### PR DESCRIPTION
```
❯ opam install . --deps-only --with-test
[WARNING] Failed checks on slack package definition from source at git+file:///Users/corentin/Dev/slack#master:
  warning 47: Synopsis (or description first line) should start with a capital and not end with a dot
```

### How to test

```
opam lint
/Users/corentin/Dev/slack/slack.opam: Passed.
```