### PR TITLE
basic cmarkit to mrkdwn converter

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -5,6 +5,7 @@
   atdgen
   atdgen-runtime
   biniou
+  cmarkit
   cstruct
   devkit
   extlib

--- a/lib/mrkdwn.ml
+++ b/lib/mrkdwn.ml
@@ -110,8 +110,21 @@ module Cmarkit_slack = struct
       | Inline.Link (l, _) -> link c l
       | _ -> false (* let the default renderer handle that *)
     in
+    let block c block =
+      let open Cmarkit in
+      let module C = Cmarkit_renderer.Context in
+      match block with
+      | Block.Heading (heading, _) ->
+        let inline = Block.Heading.inline heading in
+        C.byte c '*';
+        C.inline c inline;
+        C.byte c '*';
+        C.byte c '\n';
+        true
+      | _ -> false
+    in
     let default_renderer = Cmarkit_commonmark.renderer () in
-    let renderer = Cmarkit_renderer.make ~inline () in
+    let renderer = Cmarkit_renderer.make ~inline ~block () in
     Cmarkit_renderer.compose default_renderer renderer
 end
 

--- a/lib_test/mrkdwn/dune
+++ b/lib_test/mrkdwn/dune
@@ -1,0 +1,11 @@
+(executable
+ (name mrkdwn_of_md)
+ (libraries slack_lib cmarkit))
+
+(env
+ (_
+  (binaries
+   (./mrkdwn_of_md.exe as mrkdwn_of_md))))
+
+(cram
+ (deps %{bin:mrkdwn_of_md}))

--- a/lib_test/mrkdwn/mrkdwn_of_md.ml
+++ b/lib_test/mrkdwn/mrkdwn_of_md.ml
@@ -1,0 +1,1 @@
+let () = print_string (Cmarkit.Doc.of_string ~strict:false (In_channel.input_all stdin) |> Slack_lib.Mrkdwn.of_doc)

--- a/lib_test/mrkdwn/mrkdwn_of_md.t
+++ b/lib_test/mrkdwn/mrkdwn_of_md.t
@@ -1,0 +1,30 @@
+bold
+  $ mrkdwn_of_md << "MD"
+  > **bold**
+  > __bold__
+  > MD
+  *bold*
+  *bold*
+
+italic
+  $ mrkdwn_of_md << "MD"
+  > *italic*
+  > _italic_
+  > MD
+  _italic_
+  _italic_
+
+
+strikethrough
+  $ mrkdwn_of_md << "MD"
+  > ~~strike~~
+  > ~strike~
+  > MD
+  ~strike~
+  ~strike~
+
+link
+  $ mrkdwn_of_md << "MD"
+  > [hello](https://google.be)
+  > MD
+  <https://google.be|hello>

--- a/lib_test/mrkdwn/mrkdwn_of_md.t
+++ b/lib_test/mrkdwn/mrkdwn_of_md.t
@@ -28,3 +28,19 @@ link
   > [hello](https://google.be)
   > MD
   <https://google.be|hello>
+
+headings
+  $ mrkdwn_of_md << "MD"
+  > # one
+  > ## two
+  > ### three
+  > #### four
+  > ##### five
+  > ###### six
+  > MD
+  *one*
+  *two*
+  *three*
+  *four*
+  *five*
+  *six*


### PR DESCRIPTION
This adds a basic conversion from markdown (`Cmarkit.Doc.t`) to the `mrkdwn` syntax.

It's not complete, but at least it's a start and something we can iterate on