### PR TITLE
remove unused + update file param name

### DIFF
--- a/examples/examples.ml
+++ b/examples/examples.ml
@@ -37,6 +37,14 @@ let text =
   let doc = "text to send" in
   Arg.(value & opt string "" & info [ "t"; "text" ] ~docv:"TEXT" ~doc)
 
+let content =
+  let doc = "content/snippet to send" in
+  Arg.(value & opt (some string) None & info [ "ct"; "content" ] ~docv:"CONTENT" ~doc)
+
+let filename =
+  let doc = "filename identifier" in
+  Arg.(required & opt (some string) None & info [ "f"; "filename" ] ~docv:"FILENAME" ~doc)
+
 let update =
   let doc = "text to update first message" in
   Arg.(value & opt string "" & info [ "u"; "update" ] ~docv:"UPDATE" ~doc)
@@ -75,9 +83,9 @@ let send =
   Cmd.v info term
 
 let send_file =
-  let doc = "upload a file using Slack APIs example" in
+  let doc = "upload a file or snippet using Slack APIs example" in
   let info = Cmd.info "send_file" ~doc in
-  let term = Term.(const Sender.send_file $ channels_opt $ text) in
+  let term = Term.(const Sender.send_file $ content $ channels_opt $ filename) in
   Cmd.v info term
 
 let send_update =

--- a/examples/sender.ml
+++ b/examples/sender.ml
@@ -32,10 +32,10 @@ let send icon_url icon_emoji username channel text =
   in
   Lwt_main.run run
 
-let send_file channels content =
+let send_file content channels filename =
   let run =
     let ctx = Common_example.get_ctx_example in
-    let req = Slack_j.make_files_upload_req ?channels ~content () in
+    let req = Slack_j.make_files_upload_req ?channels ?content ~filename () in
     match%lwt Api_remote.upload_file ~ctx ~req with
     | Ok res ->
       printf "file uploaded: %s" res.file.id;

--- a/examples/sender.ml
+++ b/examples/sender.ml
@@ -35,8 +35,8 @@ let send icon_url icon_emoji username channel text =
 let send_file channels content =
   let run =
     let ctx = Common_example.get_ctx_example in
-    let file = Slack_j.make_files_upload_req ?channels ~content () in
-    match%lwt Api_remote.upload_file ~ctx ~file with
+    let req = Slack_j.make_files_upload_req ?channels ~content () in
+    match%lwt Api_remote.upload_file ~ctx ~req with
     | Ok res ->
       printf "file uploaded: %s" res.file.id;
       ( match res.file.permalink with

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -8,7 +8,7 @@ module type S = sig
   val send_message : ctx:Context.t -> msg:post_message_req -> post_message_res slack_response Lwt.t
   val send_message_webhook : ctx:Context.t -> url:string -> msg:post_message_req -> unit slack_response Lwt.t
   val update_message : ctx:Context.t -> msg:update_message_req -> update_message_res slack_response Lwt.t
-  val upload_file : ctx:Context.t -> file:files_upload_req -> files_upload_res slack_response Lwt.t
+  val upload_file : ctx:Context.t -> req:files_upload_req -> files_upload_res slack_response Lwt.t
   val get_permalink : ctx:Context.t -> req:get_permalink_req -> get_permalink_res slack_response Lwt.t
 
   (* conversations *)

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -59,9 +59,9 @@ let update_message ~ctx:_ ~msg =
   printf "%s\n" json;
   Lwt.return_ok { default_update_message_res with channel = msg.channel }
 
-let upload_file ~ctx:_ ~file =
-  let json = file |> Slack_j.string_of_files_upload_req |> Yojson.Basic.from_string |> Yojson.Basic.pretty_to_string in
-  match file.channels with
+let upload_file ~ctx:_ ~req =
+  let json = req |> Slack_j.string_of_files_upload_req |> Yojson.Basic.from_string |> Yojson.Basic.pretty_to_string in
+  match req.channels with
   | Some channels ->
     printf "will update #%s\n" channels;
     printf "%s\n" json;

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -97,12 +97,11 @@ let get_upload_url_external ~(ctx : Context.t) ~(req : Slack_t.get_upload_url_ex
     ]
     |> list_filter_opt
   in
-  let data = Web.make_url_args args in
-  let body = `Form [ "application/x-www-form-urlencoded", data ] in
-  log#info "data to upload req: %s" data;
+  let args = Web.make_url_args args in
+  let api_path = sprintf "files.getUploadURLExternal?%s" args in
   request_token_auth ~ctx
     ~name:(sprintf "files.getUploadURLExternal (%s)" req.filename)
-    ~body `POST "files.getUploadURLExternal" Slack_j.read_get_upload_url_ext_res
+    `POST api_path Slack_j.read_get_upload_url_ext_res
 
 let complete_upload_external ~(ctx : Context.t) ~(req : Slack_t.complete_upload_ext_req) =
   log#info "completing upload url for %s" @@ Slack_j.string_of_files_v2 req.files;

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -138,8 +138,8 @@ let file_list =
 let process_upload_file (channels, content) =
   Printf.printf "upload_file_to--------channels: %s--------\n" channels;
   let ctx = Context.empty_ctx () in
-  let file : Slack_t.files_upload_req = Slack_j.make_files_upload_req ~channels ~content () in
-  match%lwt Api.upload_file ~ctx ~file with
+  let req : Slack_t.files_upload_req = Slack_j.make_files_upload_req ~channels ~content () in
+  match%lwt Api.upload_file ~ctx ~req with
   | Ok res ->
     let json = res |> Slack_j.string_of_files_upload_res |> Yojson.Basic.from_string |> Yojson.Basic.pretty_to_string in
     print_endline json;


### PR DESCRIPTION
Suggestions from https://github.com/ahrefs/slack/pull/11. @thatportugueseguy

@sewenthy might want to know that the signature of the file upload api is changed. (i.e. the param name of the ~file is changed to ~req)